### PR TITLE
add npm and node version to shasum

### DIFF
--- a/npm-install-cache.sh
+++ b/npm-install-cache.sh
@@ -10,8 +10,13 @@ function get_cache_dir() {
 	echo "/tmp/npm-install-cache/$cache_id"
 }
 
+
+function get_versions() {
+	echo '_npm'$(npm --version)'_node'$(node --version)
+}
+
 function get_hash() {
-	echo $(cat package.json | shasum | sed 's/[ \t]*-[ \t\n]*$//')
+	echo $(get_versions | cat - package.json | shasum | sed 's/[ \t]*-[ \t\n]*$//')
 }
 
 function read_hash() {


### PR DESCRIPTION
Updating to node 4.1 We're getting the error

```
Error: The `libsass` binding was not found in /home/teamcity/buildAgent/work/a1f4c32b544be67/node_modules/gulp-sass/node_modules/node-sass/vendor/linux-x64-11/binding.node
This usually happens because your node version has changed.
```

updating `npm` or `node` should cause the cache to not be re-used. So I added node version and npm version to the shasum.
